### PR TITLE
Fixes #85 Duplicate return tag

### DIFF
--- a/src/main/java/io/vertx/codegen/doc/Doc.java
+++ b/src/main/java/io/vertx/codegen/doc/Doc.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
  */
 public class Doc {
 
-  private static final Pattern TAG_START = Pattern.compile("\n\\p{javaWhitespace}*@([^\\p{javaWhitespace}]+)", Pattern.MULTILINE);
+  private static final Pattern TAG_START = Pattern.compile("(^|\n)\\p{javaWhitespace}*@([^\\p{javaWhitespace}]+)", Pattern.MULTILINE);
   private static final Pattern BODY_START = Pattern.compile("\n{2,}");
 
   /**
@@ -43,7 +43,7 @@ public class Doc {
     if (matcher.find()) {
       first = javadoc.substring(0, matcher.start());
       while (true) {
-        String name = matcher.group(1);
+        String name = matcher.group(2);
         int prev = matcher.end() + 1;
         if (matcher.find()) {
           blockTags.add(new Tag(name, javadoc.substring(prev, matcher.start())));

--- a/src/test/java/io/vertx/test/codegen/DocTest.java
+++ b/src/test/java/io/vertx/test/codegen/DocTest.java
@@ -48,6 +48,9 @@ public class DocTest {
     assertComment("first\n@tag1 value1", "first", null, new Tag("tag1", "value1"));
     assertComment("first\n@tag1 line1\nline2", "first", null, new Tag("tag1", "line1\nline2"));
     assertComment("first\n@tag1 value1\n@tag2 value2", "first", null, new Tag("tag1", "value1"), new Tag("tag2", "value2"));
+    assertComment("@tag1 value", "", null, new Tag("tag1", "value"));
+    assertComment("\n@tag1 value", "", null, new Tag("tag1", "value"));
+    assertComment("@tag1 value1\n@tag2 value2", "", null, new Tag("tag1", "value1"), new Tag("tag2", "value2"));
   }
 
   private void assertComment(String text, String expectedFirstSentence, String expectedBody, Tag... expectedBlockTags) {


### PR DESCRIPTION
Fixed a regular expression in Doc class to take into account methods with no Javadoc text (tags only).

As a consequence, the firstSentence text is now empty, instead of being the Javadoc block as is.

If this is merged, we would no longer see `@author` text (see http://vertx.io/docs/vertx-redis-client/enums.html or http://vertx.io/docs/vertx-redis-client/dataobjects.html)
Or `@return` (see `errorCode` description in http://vertx.io/docs/vertx-core/dataobjects.html#GoAway)

For the former, it seems good to me. For the latter, updating the templates would be better.

Thoughts?
